### PR TITLE
Add shared UserContext

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
 import { Plus, Target, Activity, Utensils, Award, ChevronRight } from 'lucide-react-native';
+import { useUser } from '@/context/UserContext';
 
 const { width } = Dimensions.get('window');
 
 export default function Dashboard() {
-  const [userGoal, setUserGoal] = useState<'weight_loss' | 'muscle_gain'>('weight_loss');
-  const [userName] = useState('Marie');
+  const { user, setUser } = useUser();
   const [currentWeight] = useState(68);
   const [targetWeight] = useState(60);
   const [weeklyProgress] = useState(75);
@@ -24,7 +24,7 @@ export default function Dashboard() {
     }
   };
 
-  const colors = themeColors[userGoal];
+  const colors = themeColors[user.goal];
 
   const stats = [
     { label: 'Poids actuel', value: `${currentWeight} kg`, progress: ((targetWeight / currentWeight) * 100) },
@@ -44,16 +44,16 @@ export default function Dashboard() {
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.secondary }]}>
         <View style={styles.welcomeSection}>
-          <Text style={styles.welcomeText}>Bonjour {userName} 👋</Text>
+          <Text style={styles.welcomeText}>Bonjour {user.name.split(' ')[0]} 👋</Text>
           <Text style={styles.subtitle}>Prêt(e) à progresser aujourd'hui ?</Text>
         </View>
         
-        <TouchableOpacity 
+        <TouchableOpacity
           style={[styles.goalBadge, { backgroundColor: colors.primary }]}
-          onPress={() => setUserGoal(userGoal === 'weight_loss' ? 'muscle_gain' : 'weight_loss')}
+          onPress={() => setUser(u => ({ ...u, goal: u.goal === 'weight_loss' ? 'muscle_gain' : 'weight_loss' }))}
         >
           <Text style={styles.goalText}>
-            {userGoal === 'weight_loss' ? '🔥 Perte de poids' : '💪 Prise de masse'}
+            {user.goal === 'weight_loss' ? '🔥 Perte de poids' : '💪 Prise de masse'}
           </Text>
         </TouchableOpacity>
       </View>

--- a/project/app/(tabs)/plan.tsx
+++ b/project/app/(tabs)/plan.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
 import { Utensils, Activity, Moon, Droplets, Brain, ChevronRight, Target } from 'lucide-react-native';
+import { useUser } from '@/context/UserContext';
 
 const { width } = Dimensions.get('window');
 
 export default function Plan() {
   const [activeTab, setActiveTab] = useState<'nutrition' | 'workout' | 'lifestyle'>('nutrition');
-  const [userGoal] = useState<'weight_loss' | 'muscle_gain'>('weight_loss');
+  const { user } = useUser();
 
   const themeColors = {
     weight_loss: {
@@ -21,7 +22,7 @@ export default function Plan() {
     }
   };
 
-  const colors = themeColors[userGoal];
+  const colors = themeColors[user.goal];
 
   const tabs = [
     { id: 'nutrition', title: 'Nutrition', icon: Utensils },
@@ -209,7 +210,7 @@ export default function Plan() {
       <View style={[styles.header, { backgroundColor: colors.secondary }]}>
         <Text style={styles.headerTitle}>Mon Plan Personnalisé</Text>
         <Text style={styles.headerSubtitle}>
-          Optimisé pour votre objectif de {userGoal === 'weight_loss' ? 'perte de poids' : 'prise de masse'}
+          Optimisé pour votre objectif de {user.goal === 'weight_loss' ? 'perte de poids' : 'prise de masse'}
         </Text>
       </View>
 

--- a/project/app/(tabs)/profile.tsx
+++ b/project/app/(tabs)/profile.tsx
@@ -1,19 +1,12 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Switch } from 'react-native';
 import { User, Settings, Bell, Moon, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
+import { useUser } from '@/context/UserContext';
 
 export default function Profile() {
   const [notifications, setNotifications] = useState(true);
   const [darkMode, setDarkMode] = useState(false);
-  const [userInfo] = useState({
-    name: 'Marie Dupont',
-    email: 'marie.dupont@email.com',
-    age: 28,
-    height: 165,
-    goal: 'weight_loss',
-    joinDate: '2024-01-01',
-    level: 'Intermédiaire'
-  });
+  const { user } = useUser();
 
   const [preferences] = useState({
     dietType: 'Équilibrée',
@@ -66,7 +59,7 @@ export default function Profile() {
   return (
     <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
       {/* Header */}
-      <View style={[styles.header, { backgroundColor: getGoalColor(userInfo.goal) + '20' }]}>
+      <View style={[styles.header, { backgroundColor: getGoalColor(user.goal) + '20' }]}>
         <View style={styles.profileSection}>
           <TouchableOpacity style={styles.avatarContainer}>
             <View style={styles.avatar}>
@@ -78,11 +71,11 @@ export default function Profile() {
           </TouchableOpacity>
           
           <View style={styles.userInfo}>
-            <Text style={styles.userName}>{userInfo.name}</Text>
-            <Text style={styles.userEmail}>{userInfo.email}</Text>
+            <Text style={styles.userName}>{user.name}</Text>
+            <Text style={styles.userEmail}>{user.email}</Text>
             <View style={styles.goalBadge}>
-              <Text style={[styles.goalText, { color: getGoalColor(userInfo.goal) }]}>
-                {getGoalText(userInfo.goal)} • {userInfo.level}
+              <Text style={[styles.goalText, { color: getGoalColor(user.goal) }]}>
+                {getGoalText(user.goal)} • {user.level}
               </Text>
             </View>
           </View>
@@ -96,16 +89,16 @@ export default function Profile() {
         <View style={styles.detailsContainer}>
           <View style={styles.detailItem}>
             <Text style={styles.detailLabel}>Âge</Text>
-            <Text style={styles.detailValue}>{userInfo.age} ans</Text>
+            <Text style={styles.detailValue}>{user.age} ans</Text>
           </View>
           <View style={styles.detailItem}>
             <Text style={styles.detailLabel}>Taille</Text>
-            <Text style={styles.detailValue}>{userInfo.height} cm</Text>
+            <Text style={styles.detailValue}>{user.height} cm</Text>
           </View>
           <View style={styles.detailItem}>
             <Text style={styles.detailLabel}>Membre depuis</Text>
             <Text style={styles.detailValue}>
-              {new Date(userInfo.joinDate).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })}
+              {new Date(user.joinDate).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })}
             </Text>
           </View>
         </View>
@@ -117,10 +110,10 @@ export default function Profile() {
         <View style={styles.statsContainer}>
           {stats.map((stat, index) => (
             <View key={index} style={styles.statCard}>
-              <View style={[styles.statIcon, { backgroundColor: getGoalColor(userInfo.goal) + '20' }]}>
-                <stat.icon size={20} color={getGoalColor(userInfo.goal)} />
+              <View style={[styles.statIcon, { backgroundColor: getGoalColor(user.goal) + '20' }]}>
+                <stat.icon size={20} color={getGoalColor(user.goal)} />
               </View>
-              <Text style={[styles.statValue, { color: getGoalColor(userInfo.goal) }]}>
+              <Text style={[styles.statValue, { color: getGoalColor(user.goal) }]}>
                 {stat.value}
               </Text>
               <Text style={styles.statLabel}>{stat.label}</Text>
@@ -172,8 +165,8 @@ export default function Profile() {
                     <Switch
                       value={item.value}
                       onValueChange={item.onToggle}
-                      trackColor={{ false: '#E5E7EB', true: getGoalColor(userInfo.goal) + '40' }}
-                      thumbColor={item.value ? getGoalColor(userInfo.goal) : '#F3F4F6'}
+                      trackColor={{ false: '#E5E7EB', true: getGoalColor(user.goal) + '40' }}
+                      thumbColor={item.value ? getGoalColor(user.goal) : '#F3F4F6'}
                     />
                   ) : (
                     <>
@@ -195,7 +188,7 @@ export default function Profile() {
         <Text style={styles.sectionTitle}>Progression du niveau</Text>
         <View style={styles.levelCard}>
           <View style={styles.levelHeader}>
-            <Text style={styles.levelTitle}>Niveau {userInfo.level}</Text>
+            <Text style={styles.levelTitle}>Niveau {user.level}</Text>
             <Text style={styles.levelPoints}>2,450 / 3,000 XP</Text>
           </View>
           <View style={styles.levelProgress}>
@@ -204,7 +197,7 @@ export default function Profile() {
                 styles.levelProgressFill,
                 { 
                   width: '82%',
-                  backgroundColor: getGoalColor(userInfo.goal)
+                  backgroundColor: getGoalColor(user.goal)
                 }
               ]} 
             />

--- a/project/app/_layout.tsx
+++ b/project/app/_layout.tsx
@@ -2,17 +2,18 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { UserProvider } from '@/context/UserContext';
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <>
+    <UserProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />
-    </>
+    </UserProvider>
   );
 }

--- a/project/context/UserContext.tsx
+++ b/project/context/UserContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type UserGoal = 'weight_loss' | 'muscle_gain';
+
+export interface User {
+  name: string;
+  email: string;
+  age: number;
+  height: number;
+  goal: UserGoal;
+  joinDate: string;
+  level: string;
+}
+
+interface UserContextValue {
+  user: User;
+  setUser: React.Dispatch<React.SetStateAction<User>>;
+}
+
+const defaultUser: User = {
+  name: 'Marie Dupont',
+  email: 'marie.dupont@email.com',
+  age: 28,
+  height: 165,
+  goal: 'weight_loss',
+  joinDate: '2024-01-01',
+  level: 'Intermédiaire',
+};
+
+const UserContext = createContext<UserContextValue | undefined>(undefined);
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User>(defaultUser);
+
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- create `UserContext` with common user info
- wrap the app with the provider in the layout
- use the context in dashboard, plan and profile screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68448bd40ac08325be6b500c21162fd2