### PR TITLE
Fix meal suggestion navigation

### DIFF
--- a/project/app/(tabs)/meals.tsx
+++ b/project/app/(tabs)/meals.tsx
@@ -4,10 +4,14 @@ import { Plus, Search, Camera, Clock, Zap, Target, ChevronRight, Utensils, X } f
 import NutritionCard from '@/components/NutritionCard';
 import { FoodItem } from '@/types';
 import { getMeals, saveMeals } from '@/storage';
+import { useLocalSearchParams } from 'expo-router';
 
 export default function Meals() {
+  const { type } = useLocalSearchParams<{ type?: string }>();
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedMeal, setSelectedMeal] = useState<'breakfast' | 'lunch' | 'snack' | 'dinner'>('breakfast');
+  const [selectedMeal, setSelectedMeal] = useState<'breakfast' | 'lunch' | 'snack' | 'dinner'>(
+    (type as 'breakfast' | 'lunch' | 'snack' | 'dinner') || 'breakfast'
+  );
   const [showAddMeal, setShowAddMeal] = useState(false);
   const [selectedFood, setSelectedFood] = useState<FoodItem | null>(null);
   const [todayMeals, setTodayMeals] = useState<FoodItem[]>([]);

--- a/project/app/(tabs)/plan.tsx
+++ b/project/app/(tabs)/plan.tsx
@@ -2,12 +2,14 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
 import { Utensils, Activity, Moon, Droplets, Brain, ChevronRight, Target } from 'lucide-react-native';
 import { useUser } from '@/context/UserContext';
+import { useRouter } from 'expo-router';
 
 const { width } = Dimensions.get('window');
 
 export default function Plan() {
   const [activeTab, setActiveTab] = useState<'nutrition' | 'workout' | 'lifestyle'>('nutrition');
   const { user } = useUser();
+  const router = useRouter();
 
   const themeColors = {
     weight_loss: {
@@ -43,6 +45,13 @@ export default function Plan() {
       { name: 'Collation', calories: 200, suggestion: 'Pomme + amandes' },
       { name: 'Dîner', calories: 500, suggestion: 'Saumon grillé + légumes verts' }
     ]
+  };
+
+  const mealTypeMap: Record<string, string> = {
+    'Petit-déjeuner': 'breakfast',
+    'Déjeuner': 'lunch',
+    'Collation': 'snack',
+    'Dîner': 'dinner'
   };
 
   const workoutPlan = {
@@ -119,7 +128,11 @@ export default function Plan() {
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Suggestions de repas</Text>
         {nutritionPlan.meals.map((meal, index) => (
-          <TouchableOpacity key={index} style={styles.mealItem}>
+          <TouchableOpacity
+            key={index}
+            style={styles.mealItem}
+            onPress={() => router.push(`/meals?type=${mealTypeMap[meal.name]}`)}
+          >
             <View style={styles.mealInfo}>
               <Text style={styles.mealName}>{meal.name}</Text>
               <Text style={styles.mealSuggestion}>{meal.suggestion}</Text>


### PR DESCRIPTION
## Summary
- link the plan page meal suggestions to the meal screen
- allow the meal screen to read the initial meal type from query params

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the `--jsx` flag is provided and missing modules)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452e6e1db88325a46810c9e4bd599c