### PR TITLE
Fix profile menu navigation

### DIFF
--- a/project/app/(tabs)/profile.tsx
+++ b/project/app/(tabs)/profile.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Switch } from 'react-native';
 import { User, Settings, Bell, Moon, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
 import { useUser } from '@/context/UserContext';
+import { useRouter } from 'expo-router';
 
 export default function Profile() {
   const [notifications, setNotifications] = useState(true);
   const [darkMode, setDarkMode] = useState(false);
   const { user } = useUser();
+  const router = useRouter();
 
   const [preferences] = useState({
     dietType: 'Équilibrée',
@@ -25,8 +27,8 @@ export default function Profile() {
     {
       title: 'Mon compte',
       items: [
-        { label: 'Informations personnelles', icon: User, onPress: () => {} },
-        { label: 'Objectifs et préférences', icon: Target, onPress: () => {} },
+        { label: 'Informations personnelles', icon: User, onPress: () => router.push('/account') },
+        { label: 'Objectifs et préférences', icon: Target, onPress: () => router.push('/account') },
         { label: 'Notifications', icon: Bell, hasSwitch: true, value: notifications, onToggle: setNotifications }
       ]
     },
@@ -34,16 +36,16 @@ export default function Profile() {
       title: 'Paramètres',
       items: [
         { label: 'Mode sombre', icon: Moon, hasSwitch: true, value: darkMode, onToggle: setDarkMode },
-        { label: 'Langue', icon: Globe, value: preferences.language, onPress: () => {} },
-        { label: 'Unités de mesure', icon: Settings, value: preferences.units, onPress: () => {} }
+        { label: 'Langue', icon: Globe, value: preferences.language, onPress: () => router.push('/settings') },
+        { label: 'Unités de mesure', icon: Settings, value: preferences.units, onPress: () => router.push('/settings') }
       ]
     },
     {
       title: 'Support',
       items: [
-        { label: 'Centre d\'aide', icon: Settings, onPress: () => {} },
-        { label: 'Nous contacter', icon: Settings, onPress: () => {} },
-        { label: 'Conditions d\'utilisation', icon: Settings, onPress: () => {} }
+        { label: 'Centre d\'aide', icon: Settings, onPress: () => router.push('/support') },
+        { label: 'Nous contacter', icon: Settings, onPress: () => router.push('/support') },
+        { label: 'Conditions d\'utilisation', icon: Settings, onPress: () => router.push('/support') }
       ]
     }
   ];

--- a/project/app/account.tsx
+++ b/project/app/account.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function AccountScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Mon compte</Text>
+      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F9FAFB',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#1F2937',
+  },
+  text: {
+    fontSize: 16,
+    color: '#4B5563',
+    textAlign: 'center',
+  },
+});

--- a/project/app/settings.tsx
+++ b/project/app/settings.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Paramètres</Text>
+      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F9FAFB',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#1F2937',
+  },
+  text: {
+    fontSize: 16,
+    color: '#4B5563',
+    textAlign: 'center',
+  },
+});

--- a/project/app/support.tsx
+++ b/project/app/support.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SupportScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Support</Text>
+      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F9FAFB',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#1F2937',
+  },
+  text: {
+    fontSize: 16,
+    color: '#4B5563',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- create placeholder screens for account, settings and support
- navigate to these screens when pressing profile items

## Testing
- `npm install --legacy-peer-deps`
- `npx tsc --noEmit` *(fails: meal.quantity possibly undefined)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684549d980748325ae62fc2a2e013994