### PR TITLE
Add dark mode toggle

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
-import { Plus, Target, Activity, Utensils, Award, ChevronRight } from 'lucide-react-native';
+import { Plus, Target, Activity, Utensils, Award, ChevronRight, Moon, Sun } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 import { useUser } from '@/context/UserContext';
+import { useTheme } from '@/context/ThemeContext';
 
 const { width } = Dimensions.get('window');
 
 export default function Dashboard() {
   const { user, setUser } = useUser();
   const router = useRouter();
+  const { theme, toggleTheme } = useTheme();
   const [currentWeight] = useState(68);
   const [targetWeight] = useState(60);
   const [weeklyProgress] = useState(75);
@@ -42,9 +44,19 @@ export default function Dashboard() {
   ];
 
   return (
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={[styles.container, theme === 'dark' && styles.containerDark]}
+      showsVerticalScrollIndicator={false}
+    >
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.secondary }]}>
+        <TouchableOpacity onPress={toggleTheme} style={styles.themeToggle}>
+          {theme === 'light' ? (
+            <Moon size={24} color="#1F2937" />
+          ) : (
+            <Sun size={24} color="#F9FAFB" />
+          )}
+        </TouchableOpacity>
         <View style={styles.welcomeSection}>
           <Text style={styles.welcomeText}>Bonjour {user.name.split(' ')[0]} 👋</Text>
           <Text style={styles.subtitle}>Prêt(e) à progresser aujourd'hui ?</Text>
@@ -120,11 +132,19 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#F9FAFB',
   },
+  containerDark: {
+    backgroundColor: '#1F2937',
+  },
   header: {
     padding: 20,
     paddingTop: 60,
     borderBottomLeftRadius: 24,
     borderBottomRightRadius: 24,
+  },
+  themeToggle: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
   },
   welcomeSection: {
     marginBottom: 16,

--- a/project/app/(tabs)/profile.tsx
+++ b/project/app/(tabs)/profile.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Switch } from 'react-native';
-import { User, Settings, Bell, Moon, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
+import { User, Settings, Bell, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
 import { useUser } from '@/context/UserContext';
 import { useRouter } from 'expo-router';
 
 export default function Profile() {
   const [notifications, setNotifications] = useState(true);
-  const [darkMode, setDarkMode] = useState(false);
   const { user } = useUser();
   const router = useRouter();
 
@@ -35,7 +34,6 @@ export default function Profile() {
     {
       title: 'Paramètres',
       items: [
-        { label: 'Mode sombre', icon: Moon, hasSwitch: true, value: darkMode, onToggle: setDarkMode },
         { label: 'Langue', icon: Globe, value: preferences.language, onPress: () => router.push('/settings') },
         { label: 'Unités de mesure', icon: Settings, value: preferences.units, onPress: () => router.push('/settings') }
       ]

--- a/project/app/_layout.tsx
+++ b/project/app/_layout.tsx
@@ -3,17 +3,20 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { UserProvider } from '@/context/UserContext';
+import { ThemeProvider } from '@/context/ThemeContext';
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <UserProvider>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </UserProvider>
+    <ThemeProvider>
+      <UserProvider>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </UserProvider>
+    </ThemeProvider>
   );
 }

--- a/project/context/ThemeContext.tsx
+++ b/project/context/ThemeContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<ThemeMode>('light');
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider context
- wrap app with ThemeProvider
- allow toggling dark/light mode from the home screen header
- remove the dark mode switch from the profile screen

## Testing
- `npm install` *(fails: dependency resolution errors)*
- `npx tsc --noEmit` *(fails: cannot find modules and JSX errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454c1254808325992013562918990a