### PR TITLE
Add global dark mode support

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
-import { Plus, Target, Activity, Utensils, Award, ChevronRight } from 'lucide-react-native';
+import { Plus, Target, Activity, Utensils, Award, ChevronRight, Moon, Sun } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 import { useUser } from '@/context/UserContext';
+import { useTheme } from '@/context/ThemeContext';
 
 const { width } = Dimensions.get('window');
 
 export default function Dashboard() {
   const { user, setUser } = useUser();
   const router = useRouter();
+  const { theme, toggleTheme, colors } = useTheme();
   const [currentWeight] = useState(68);
   const [targetWeight] = useState(60);
   const [weeklyProgress] = useState(75);
@@ -42,12 +44,22 @@ export default function Dashboard() {
   ];
 
   return (
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      showsVerticalScrollIndicator={false}
+    >
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.secondary }]}>
+        <TouchableOpacity onPress={toggleTheme} style={styles.themeToggle}>
+          {theme === 'light' ? (
+            <Moon size={24} color="#1F2937" />
+          ) : (
+            <Sun size={24} color="#F9FAFB" />
+          )}
+        </TouchableOpacity>
         <View style={styles.welcomeSection}>
-          <Text style={styles.welcomeText}>Bonjour {user.name.split(' ')[0]} 👋</Text>
-          <Text style={styles.subtitle}>Prêt(e) à progresser aujourd'hui ?</Text>
+          <Text style={[styles.welcomeText, { color: colors.text }]}>Bonjour {user.name.split(' ')[0]} 👋</Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Prêt(e) à progresser aujourd'hui ?</Text>
         </View>
         
         <TouchableOpacity
@@ -62,13 +74,13 @@ export default function Dashboard() {
 
       {/* Stats Cards */}
       <View style={styles.statsContainer}>
-        <Text style={styles.sectionTitle}>Votre progression</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Votre progression</Text>
         <View style={styles.statsGrid}>
           {stats.map((stat, index) => (
-            <View key={index} style={styles.statCard}>
-              <Text style={styles.statLabel}>{stat.label}</Text>
+            <View key={index} style={[styles.statCard, { backgroundColor: colors.card }]}>
+              <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{stat.label}</Text>
               <Text style={[styles.statValue, { color: colors.primary }]}>{stat.value}</Text>
-              <View style={styles.progressBar}>
+              <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
                 <View 
                   style={[
                     styles.progressFill, 
@@ -83,18 +95,18 @@ export default function Dashboard() {
 
       {/* Quick Actions */}
       <View style={styles.actionsContainer}>
-        <Text style={styles.sectionTitle}>Actions rapides</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Actions rapides</Text>
         {quickActions.map((action, index) => (
           <TouchableOpacity
             key={index}
-            style={styles.actionCard}
+            style={[styles.actionCard, { backgroundColor: colors.card }]}
             onPress={() => router.push(action.href)}
           >
             <View style={styles.actionLeft}>
               <View style={[styles.iconContainer, { backgroundColor: action.color + '20' }]}>
                 <action.icon size={24} color={action.color} />
               </View>
-              <Text style={styles.actionTitle}>{action.title}</Text>
+              <Text style={[styles.actionTitle, { color: colors.text }]}>{action.title}</Text>
             </View>
             <ChevronRight size={20} color="#9CA3AF" />
           </TouchableOpacity>
@@ -125,6 +137,11 @@ const styles = StyleSheet.create({
     paddingTop: 60,
     borderBottomLeftRadius: 24,
     borderBottomRightRadius: 24,
+  },
+  themeToggle: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
   },
   welcomeSection: {
     marginBottom: 16,

--- a/project/app/(tabs)/meals.tsx
+++ b/project/app/(tabs)/meals.tsx
@@ -5,6 +5,7 @@ import NutritionCard from '@/components/NutritionCard';
 import { FoodItem } from '@/types';
 import { getMeals, saveMeals } from '@/storage';
 import { useLocalSearchParams } from 'expo-router';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function Meals() {
   const { type } = useLocalSearchParams<{ type?: string }>();
@@ -15,6 +16,7 @@ export default function Meals() {
   const [showAddMeal, setShowAddMeal] = useState(false);
   const [selectedFood, setSelectedFood] = useState<FoodItem | null>(null);
   const [todayMeals, setTodayMeals] = useState<FoodItem[]>([]);
+  const { colors } = useTheme();
 
   useEffect(() => {
     getMeals().then(setTodayMeals);
@@ -102,11 +104,11 @@ export default function Meals() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.background }] }>
       {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Mes Repas</Text>
-        <Text style={styles.headerSubtitle}>Suivez votre nutrition quotidienne</Text>
+      <View style={[styles.header, { backgroundColor: colors.secondary || '#FEE2E2' }]}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Mes Repas</Text>
+        <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Suivez votre nutrition quotidienne</Text>
         
         {/* Daily Progress */}
         <View style={styles.progressContainer}>

--- a/project/app/(tabs)/plan.tsx
+++ b/project/app/(tabs)/plan.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from
 import { Utensils, Activity, Moon, Droplets, Brain, ChevronRight, Target } from 'lucide-react-native';
 import { useUser } from '@/context/UserContext';
 import { useRouter } from 'expo-router';
+import { useTheme } from '@/context/ThemeContext';
 
 const { width } = Dimensions.get('window');
 
@@ -10,6 +11,7 @@ export default function Plan() {
   const [activeTab, setActiveTab] = useState<'nutrition' | 'workout' | 'lifestyle'>('nutrition');
   const { user } = useUser();
   const router = useRouter();
+  const { colors } = useTheme();
 
   const themeColors = {
     weight_loss: {
@@ -75,8 +77,8 @@ export default function Plan() {
   const renderNutritionTab = () => (
     <View>
       {/* Calories Overview */}
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Objectif calorique quotidien</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Objectif calorique quotidien</Text>
         <View style={styles.calorieContainer}>
           <Text style={[styles.calorieNumber, { color: colors.primary }]}>
             {nutritionPlan.calories.current}
@@ -97,8 +99,8 @@ export default function Plan() {
       </View>
 
       {/* Macros */}
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Répartition des macronutriments</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Répartition des macronutriments</Text>
         <View style={styles.macrosContainer}>
           {Object.entries(nutritionPlan.macros).map(([key, macro]) => (
             <View key={key} style={styles.macroItem}>
@@ -125,8 +127,8 @@ export default function Plan() {
       </View>
 
       {/* Meal Suggestions */}
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Suggestions de repas</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Suggestions de repas</Text>
         {nutritionPlan.meals.map((meal, index) => (
           <TouchableOpacity
             key={index}
@@ -150,8 +152,8 @@ export default function Plan() {
   const renderWorkoutTab = () => (
     <View>
       {/* Weekly Progress */}
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Progression hebdomadaire</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Progression hebdomadaire</Text>
         <View style={styles.workoutProgress}>
           <Text style={[styles.workoutNumber, { color: colors.primary }]}>
             {workoutPlan.completed} / {workoutPlan.weeklyGoal}
@@ -172,8 +174,8 @@ export default function Plan() {
       </View>
 
       {/* Weekly Schedule */}
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Planning de la semaine</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Planning de la semaine</Text>
         {workoutPlan.sessions.map((session, index) => (
           <TouchableOpacity key={index} style={styles.sessionItem}>
             <View style={styles.sessionLeft}>
@@ -196,8 +198,8 @@ export default function Plan() {
 
   const renderLifestyleTab = () => (
     <View>
-      <View style={styles.card}>
-        <Text style={styles.cardTitle}>Conseils bien-être</Text>
+      <View style={[styles.card, { backgroundColor: colors.card }]}>
+        <Text style={[styles.cardTitle, { color: colors.text }]}>Conseils bien-être</Text>
         {lifestyleTips.map((tip, index) => (
           <View key={index} style={styles.tipItem}>
             <View style={styles.tipHeader}>
@@ -218,11 +220,11 @@ export default function Plan() {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.secondary }]}>
-        <Text style={styles.headerTitle}>Mon Plan Personnalisé</Text>
-        <Text style={styles.headerSubtitle}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Mon Plan Personnalisé</Text>
+        <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
           Optimisé pour votre objectif de {user.goal === 'weight_loss' ? 'perte de poids' : 'prise de masse'}
         </Text>
       </View>

--- a/project/app/(tabs)/profile.tsx
+++ b/project/app/(tabs)/profile.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Switch } from 'react-native';
-import { User, Settings, Bell, Moon, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
+import { User, Settings, Bell, Globe, Award, Target, ChevronRight, CreditCard as Edit, Camera, Activity } from 'lucide-react-native';
 import { useUser } from '@/context/UserContext';
 import { useRouter } from 'expo-router';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function Profile() {
   const [notifications, setNotifications] = useState(true);
-  const [darkMode, setDarkMode] = useState(false);
   const { user } = useUser();
   const router = useRouter();
+  const { colors } = useTheme();
 
   const [preferences] = useState({
     dietType: 'Équilibrée',
@@ -35,7 +36,6 @@ export default function Profile() {
     {
       title: 'Paramètres',
       items: [
-        { label: 'Mode sombre', icon: Moon, hasSwitch: true, value: darkMode, onToggle: setDarkMode },
         { label: 'Langue', icon: Globe, value: preferences.language, onPress: () => router.push('/settings') },
         { label: 'Unités de mesure', icon: Settings, value: preferences.units, onPress: () => router.push('/settings') }
       ]
@@ -59,7 +59,7 @@ export default function Profile() {
   };
 
   return (
-    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+    <ScrollView style={[styles.container, { backgroundColor: colors.background }]} showsVerticalScrollIndicator={false}>
       {/* Header */}
       <View style={[styles.header, { backgroundColor: getGoalColor(user.goal) + '20' }]}>
         <View style={styles.profileSection}>
@@ -73,8 +73,8 @@ export default function Profile() {
           </TouchableOpacity>
           
           <View style={styles.userInfo}>
-            <Text style={styles.userName}>{user.name}</Text>
-            <Text style={styles.userEmail}>{user.email}</Text>
+            <Text style={[styles.userName, { color: colors.text }]}>{user.name}</Text>
+            <Text style={[styles.userEmail, { color: colors.textSecondary }]}>{user.email}</Text>
             <View style={styles.goalBadge}>
               <Text style={[styles.goalText, { color: getGoalColor(user.goal) }]}>
                 {getGoalText(user.goal)} • {user.level}
@@ -108,7 +108,7 @@ export default function Profile() {
 
       {/* Stats */}
       <View style={styles.statsSection}>
-        <Text style={styles.sectionTitle}>Vos statistiques</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Vos statistiques</Text>
         <View style={styles.statsContainer}>
           {stats.map((stat, index) => (
             <View key={index} style={styles.statCard}>
@@ -126,15 +126,15 @@ export default function Profile() {
 
       {/* Preferences Overview */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Mes préférences</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Mes préférences</Text>
         <View style={styles.preferencesCard}>
           <View style={styles.preferenceItem}>
-            <Text style={styles.preferenceLabel}>Régime alimentaire</Text>
-            <Text style={styles.preferenceValue}>{preferences.dietType}</Text>
+            <Text style={[styles.preferenceLabel, { color: colors.textSecondary }]}>Régime alimentaire</Text>
+            <Text style={[styles.preferenceValue, { color: colors.text }]}>{preferences.dietType}</Text>
           </View>
           <View style={styles.preferenceItem}>
-            <Text style={styles.preferenceLabel}>Allergies</Text>
-            <Text style={styles.preferenceValue}>
+            <Text style={[styles.preferenceLabel, { color: colors.textSecondary }]}>Allergies</Text>
+            <Text style={[styles.preferenceValue, { color: colors.text }]}>
               {preferences.allergies.length > 0 ? preferences.allergies.join(', ') : 'Aucune'}
             </Text>
           </View>
@@ -144,7 +144,7 @@ export default function Profile() {
       {/* Menu Sections */}
       {menuSections.map((section, sectionIndex) => (
         <View key={sectionIndex} style={styles.section}>
-          <Text style={styles.sectionTitle}>{section.title}</Text>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>{section.title}</Text>
           <View style={styles.menuCard}>
             {section.items.map((item, itemIndex) => (
               <TouchableOpacity 
@@ -159,7 +159,7 @@ export default function Profile() {
                   <View style={styles.menuIcon}>
                     <item.icon size={20} color="#6B7280" />
                   </View>
-                  <Text style={styles.menuLabel}>{item.label}</Text>
+                  <Text style={[styles.menuLabel, { color: colors.text }]}>{item.label}</Text>
                 </View>
                 
                 <View style={styles.menuRight}>
@@ -187,7 +187,7 @@ export default function Profile() {
 
       {/* Level Progress */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Progression du niveau</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Progression du niveau</Text>
         <View style={styles.levelCard}>
           <View style={styles.levelHeader}>
             <Text style={styles.levelTitle}>Niveau {user.level}</Text>
@@ -212,7 +212,7 @@ export default function Profile() {
 
       {/* Achievements Preview */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Réussites récentes</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Réussites récentes</Text>
         <View style={styles.achievementPreview}>
           <View style={styles.achievementItem}>
             <Text style={styles.achievementEmoji}>🔥</Text>

--- a/project/app/(tabs)/progress.tsx
+++ b/project/app/(tabs)/progress.tsx
@@ -3,12 +3,14 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Image
 import { TrendingUp, Camera, Calendar, Target, Award, ChevronRight, Scale, Ruler } from 'lucide-react-native';
 import ProgressChart from '@/components/ProgressChart';
 import { getWeights, WeightEntry } from '@/storage';
+import { useTheme } from '@/context/ThemeContext';
 
 const { width } = Dimensions.get('window');
 
 export default function Progress() {
   const [activeTab, setActiveTab] = useState<'weight' | 'measurements' | 'photos'>('weight');
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month' | '3months'>('month');
+  const { colors } = useTheme();
 
   const tabs = [
     { id: 'weight', title: 'Poids', icon: Scale },
@@ -242,11 +244,11 @@ export default function Progress() {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Mes Progrès</Text>
-        <Text style={styles.headerSubtitle}>Suivez votre transformation</Text>
+      <View style={[styles.header, { backgroundColor: colors.secondary || '#E0E7FF' }]}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Mes Progrès</Text>
+        <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Suivez votre transformation</Text>
       </View>
 
       {/* Tabs */}

--- a/project/app/(tabs)/workouts.tsx
+++ b/project/app/(tabs)/workouts.tsx
@@ -4,6 +4,7 @@ import Slider from '@react-native-community/slider';
 import { Play, Plus, Clock, Zap, Target, Trophy, ChevronRight, Activity, Heart, X, Dumbbell, StretchHorizontal, Bookmark, Repeat } from 'lucide-react-native';
 import WorkoutTimer from '@/components/WorkoutTimer';
 import { getWorkouts, saveWorkouts, WorkoutEntry } from '@/storage';
+import { useTheme } from '@/context/ThemeContext';
 
 const { width } = Dimensions.get('window');
 
@@ -17,6 +18,7 @@ export default function Workouts() {
   const [newWorkoutDuration, setNewWorkoutDuration] = useState(30);
   const [newWorkoutType, setNewWorkoutType] = useState<'cardio' | 'strength' | 'flexibility'>('cardio');
   const [newWorkoutLevel, setNewWorkoutLevel] = useState<'Débutant' | 'Intermédiaire' | 'Avancé'>('Débutant');
+  const { colors } = useTheme();
   const [newWorkoutCalories, setNewWorkoutCalories] = useState(240);
   const [newWorkoutEquipment, setNewWorkoutEquipment] = useState('');
   const [newWorkoutDescription, setNewWorkoutDescription] = useState('');
@@ -198,11 +200,11 @@ export default function Workouts() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.background }] }>
       {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Mes Entraînements</Text>
-        <Text style={styles.headerSubtitle}>Restez actif et atteignez vos objectifs</Text>
+      <View style={[styles.header, { backgroundColor: colors.secondary || '#FEE2E2' }]}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Mes Entraînements</Text>
+        <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>Restez actif et atteignez vos objectifs</Text>
         
         {/* Weekly Stats */}
         <View style={styles.statsContainer}>

--- a/project/app/_layout.tsx
+++ b/project/app/_layout.tsx
@@ -3,17 +3,35 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { UserProvider } from '@/context/UserContext';
+import { ThemeProvider, useTheme } from '@/context/ThemeContext';
+import { View } from 'react-native';
+
+function AppContainer() {
+  const { colors, theme } = useTheme();
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: colors.background }
+        }}
+      >
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style={theme === 'dark' ? 'light' : 'dark'} />
+    </View>
+  );
+}
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <UserProvider>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </UserProvider>
+    <ThemeProvider>
+      <UserProvider>
+        <AppContainer />
+      </UserProvider>
+    </ThemeProvider>
   );
 }

--- a/project/app/account.tsx
+++ b/project/app/account.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function AccountScreen() {
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Mon compte</Text>
@@ -10,23 +13,24 @@ export default function AccountScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#F9FAFB',
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    color: '#1F2937',
-  },
-  text: {
-    fontSize: 16,
-    color: '#4B5563',
-    textAlign: 'center',
-  },
-});
+const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.background,
+      padding: 20,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      marginBottom: 12,
+      color: colors.text,
+    },
+    text: {
+      fontSize: 16,
+      color: colors.textSecondary,
+      textAlign: 'center',
+    },
+  });

--- a/project/app/settings.tsx
+++ b/project/app/settings.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function SettingsScreen() {
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Paramètres</Text>
@@ -10,23 +13,24 @@ export default function SettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#F9FAFB',
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    color: '#1F2937',
-  },
-  text: {
-    fontSize: 16,
-    color: '#4B5563',
-    textAlign: 'center',
-  },
-});
+const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.background,
+      padding: 20,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      marginBottom: 12,
+      color: colors.text,
+    },
+    text: {
+      fontSize: 16,
+      color: colors.textSecondary,
+      textAlign: 'center',
+    },
+  });

--- a/project/app/support.tsx
+++ b/project/app/support.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function SupportScreen() {
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Support</Text>
@@ -10,23 +13,24 @@ export default function SupportScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#F9FAFB',
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    color: '#1F2937',
-  },
-  text: {
-    fontSize: 16,
-    color: '#4B5563',
-    textAlign: 'center',
-  },
-});
+const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.background,
+      padding: 20,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      marginBottom: 12,
+      color: colors.text,
+    },
+    text: {
+      fontSize: 16,
+      color: colors.textSecondary,
+      textAlign: 'center',
+    },
+  });

--- a/project/context/ThemeContext.tsx
+++ b/project/context/ThemeContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Text } from 'react-native';
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface ThemeColors {
+  background: string;
+  card: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+}
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  colors: ThemeColors;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<ThemeMode>('light');
+
+  const themes: Record<ThemeMode, ThemeColors> = {
+    light: {
+      background: '#F9FAFB',
+      card: '#FFFFFF',
+      text: '#1F2937',
+      textSecondary: '#6B7280',
+      border: '#E5E7EB'
+    },
+    dark: {
+      background: '#1F2937',
+      card: '#374151',
+      text: '#F9FAFB',
+      textSecondary: '#D1D5DB',
+      border: '#4B5563'
+    }
+  };
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const colors = themes[theme];
+
+  useEffect(() => {
+    Text.defaultProps = Text.defaultProps || {};
+    Text.defaultProps.style = { ...(Text.defaultProps.style || {}), color: colors.text };
+  }, [colors]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- extend ThemeContext with color palettes
- apply theme background and text colors in root layout
- update screens to respect ThemeContext colors
- keep dark mode toggle in the home screen

## Testing
- `npm install` *(fails: dependency resolution errors)*
- `npx tsc --noEmit` *(fails: cannot find modules and JSX errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454c1254808325992013562918990a