### PR TITLE
Improve dark mode support

### DIFF
--- a/project/app/(tabs)/meals.tsx
+++ b/project/app/(tabs)/meals.tsx
@@ -17,6 +17,7 @@ export default function Meals() {
   const [selectedFood, setSelectedFood] = useState<FoodItem | null>(null);
   const [todayMeals, setTodayMeals] = useState<FoodItem[]>([]);
   const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   useEffect(() => {
     getMeals().then(setTodayMeals);
@@ -327,13 +328,16 @@ export default function Meals() {
   );
 }
 
-const styles = StyleSheet.create({
+const getStyles = (
+  colors: import('@/context/ThemeContext').ThemeColors
+) =>
+  StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: colors.background,
   },
   header: {
-    backgroundColor: '#FEE2E2',
+    backgroundColor: colors.card,
     padding: 20,
     paddingTop: 60,
     borderBottomLeftRadius: 24,
@@ -342,16 +346,16 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 4,
   },
   headerSubtitle: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 16,
   },
   progressContainer: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
   },
@@ -360,7 +364,7 @@ const styles = StyleSheet.create({
   },
   progressLabel: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 4,
   },
   progressValue: {
@@ -372,7 +376,7 @@ const styles = StyleSheet.create({
   progressBar: {
     width: '100%',
     height: 6,
-    backgroundColor: '#E5E7EB',
+    backgroundColor: colors.border,
     borderRadius: 3,
     overflow: 'hidden',
   },
@@ -388,7 +392,7 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   mealTypeCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 12,
     alignItems: 'center',
@@ -406,7 +410,7 @@ const styles = StyleSheet.create({
   mealTypeLabel: {
     fontSize: 12,
     fontWeight: '600',
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 4,
   },
   mealTypeLabelSelected: {
@@ -420,7 +424,7 @@ const styles = StyleSheet.create({
   mealTypeProgress: {
     width: '100%',
     height: 2,
-    backgroundColor: '#E5E7EB',
+    backgroundColor: colors.border,
     borderRadius: 1,
     overflow: 'hidden',
   },
@@ -438,7 +442,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
@@ -447,10 +451,10 @@ const styles = StyleSheet.create({
   searchInput: {
     flex: 1,
     fontSize: 16,
-    color: '#1F2937',
+    color: colors.text,
   },
   cameraButton: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 12,
     alignItems: 'center',
@@ -466,7 +470,7 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 16,
   },
   quickActions: {
@@ -475,7 +479,7 @@ const styles = StyleSheet.create({
   },
   quickAction: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
     alignItems: 'center',
@@ -484,11 +488,11 @@ const styles = StyleSheet.create({
   quickActionText: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#1F2937',
+    color: colors.text,
     textAlign: 'center',
   },
   suggestionCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
@@ -516,7 +520,7 @@ const styles = StyleSheet.create({
   suggestionName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 4,
   },
   macroRow: {
@@ -525,30 +529,30 @@ const styles = StyleSheet.create({
   },
   macroText: {
     fontSize: 12,
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   macroSummary: {
     gap: 16,
   },
   macroSummaryItem: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
   },
   macroSummaryLabel: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 4,
   },
   macroSummaryValue: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 8,
   },
   macroSummaryProgress: {
     height: 4,
-    backgroundColor: '#E5E7EB',
+    backgroundColor: colors.border,
     borderRadius: 2,
     overflow: 'hidden',
   },
@@ -558,7 +562,7 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: colors.background,
   },
   modalHeader: {
     flexDirection: 'row',
@@ -566,14 +570,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 20,
     paddingTop: 60,
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: colors.border,
   },
   modalTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
   },
   closeButton: {
     padding: 8,

--- a/project/app/(tabs)/workouts.tsx
+++ b/project/app/(tabs)/workouts.tsx
@@ -610,7 +610,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   categoryLabel: {
     fontSize: 12,
     fontWeight: '600',
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   categoryLabelSelected: {
     color: '#10B981',
@@ -625,7 +625,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   sectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 16,
   },
   quickStartContainer: {
@@ -653,24 +653,24 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   },
   createWorkoutCard: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 16,
     padding: 20,
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,
-    borderColor: '#E5E7EB',
+    borderColor: colors.border,
     borderStyle: 'dashed',
   },
   createWorkoutText: {
-    color: '#6B7280',
+    color: colors.textSecondary,
     fontSize: 12,
     fontWeight: '600',
     marginTop: 8,
     textAlign: 'center',
   },
   workoutCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 16,
     padding: 16,
     marginBottom: 12,
@@ -703,12 +703,12 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   workoutName: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 4,
   },
   workoutDescription: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 8,
   },
   workoutMeta: {
@@ -723,7 +723,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   },
   metaText: {
     fontSize: 12,
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   difficultyBadge: {
     paddingHorizontal: 8,
@@ -735,7 +735,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     fontWeight: '600',
   },
   historyCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
@@ -762,12 +762,12 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   historyName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 2,
   },
   historyDate: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginBottom: 4,
   },
   historyMeta: {
@@ -779,7 +779,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     color: '#9CA3AF',
   },
   insightsCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 16,
     padding: 20,
     gap: 16,
@@ -792,12 +792,12 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   insightText: {
     flex: 1,
     fontSize: 14,
-    color: '#1F2937',
+    color: colors.text,
     lineHeight: 20,
   },
   modalContainer: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: colors.background,
   },
   modalHeader: {
     flexDirection: 'row',
@@ -805,14 +805,14 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     alignItems: 'center',
     padding: 20,
     paddingTop: 60,
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: colors.border,
   },
   modalTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
   },
   closeButton: {
     padding: 8,
@@ -827,11 +827,11 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   exercisesTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 16,
   },
   exerciseItem: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
@@ -842,7 +842,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   exerciseName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1F2937',
+    color: colors.text,
     flex: 1,
   },
   exerciseDetails: {
@@ -855,18 +855,18 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   },
   exerciseRest: {
     fontSize: 12,
-    color: '#6B7280',
+    color: colors.textSecondary,
     marginTop: 2,
   },
   input: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
     fontSize: 16,
-    color: '#1F2937',
+    color: colors.text,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: colors.border,
     marginBottom: 16,
   },
   sliderRow: {
@@ -874,7 +874,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   },
   sliderLabel: {
     fontSize: 14,
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 8,
   },
   slider: {
@@ -892,17 +892,17 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     justifyContent: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: colors.border,
     borderRadius: 12,
     marginHorizontal: 4,
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
   },
   typeOptionSelected: {
     backgroundColor: '#10B981',
   },
   typeLabel: {
     marginLeft: 8,
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   typeLabelSelected: {
     color: 'white',
@@ -911,17 +911,17 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     flex: 1,
     paddingVertical: 8,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: colors.border,
     borderRadius: 12,
     marginHorizontal: 4,
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
   },
   levelOptionSelected: {
     backgroundColor: '#10B981',
   },
   levelLabel: {
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   levelLabelSelected: {
     color: 'white',
@@ -935,10 +935,10 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   toggleLabel: {
     flex: 1,
     marginLeft: 8,
-    color: '#1F2937',
+    color: colors.text,
   },
   previewCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.card,
     borderRadius: 12,
     padding: 16,
     marginBottom: 20,
@@ -947,12 +947,12 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   previewTitle: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1F2937',
+    color: colors.text,
     marginBottom: 4,
   },
   previewText: {
     fontSize: 14,
-    color: '#6B7280',
+    color: colors.textSecondary,
   },
   addButton: {
     backgroundColor: '#10B981',


### PR DESCRIPTION
## Summary
- apply theme-aware styles to the meals page
- apply theme-aware styles to the workouts page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad4f59e48325b0236775e87c028d