### PR TITLE
Add basic profile related screens

### DIFF
--- a/project/app/account.tsx
+++ b/project/app/account.tsx
@@ -1,14 +1,76 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
 import { useTheme } from '@/context/ThemeContext';
+import { useUser } from '@/context/UserContext';
 
 export default function AccountScreen() {
   const { colors } = useTheme();
+  const { user, setUser } = useUser();
+
+  const [name, setName] = useState(user.name);
+  const [email, setEmail] = useState(user.email);
+  const [age, setAge] = useState(String(user.age));
+  const [height, setHeight] = useState(String(user.height));
+
   const styles = getStyles(colors);
+
+  const saveProfile = () => {
+    setUser((u) => ({
+      ...u,
+      name,
+      email,
+      age: Number(age),
+      height: Number(height),
+    }));
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Mon compte</Text>
-      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+      <View style={styles.formRow}>
+        <Text style={styles.label}>Nom</Text>
+        <TextInput
+          style={styles.input}
+          value={name}
+          onChangeText={setName}
+        />
+      </View>
+      <View style={styles.formRow}>
+        <Text style={styles.label}>Email</Text>
+        <TextInput
+          style={styles.input}
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+        />
+      </View>
+      <View style={styles.formRow}>
+        <Text style={styles.label}>Âge</Text>
+        <TextInput
+          style={styles.input}
+          value={age}
+          onChangeText={setAge}
+          keyboardType="numeric"
+        />
+      </View>
+      <View style={styles.formRow}>
+        <Text style={styles.label}>Taille (cm)</Text>
+        <TextInput
+          style={styles.input}
+          value={height}
+          onChangeText={setHeight}
+          keyboardType="numeric"
+        />
+      </View>
+      <TouchableOpacity style={styles.button} onPress={saveProfile}>
+        <Text style={styles.buttonText}>Sauvegarder</Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -17,20 +79,42 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
       backgroundColor: colors.background,
       padding: 20,
     },
     title: {
       fontSize: 24,
       fontWeight: 'bold',
-      marginBottom: 12,
+      marginBottom: 20,
+      color: colors.text,
+      textAlign: 'center',
+    },
+    formRow: {
+      marginBottom: 16,
+    },
+    label: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      marginBottom: 4,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+      padding: 8,
+      backgroundColor: colors.card,
       color: colors.text,
     },
-    text: {
+    button: {
+      marginTop: 20,
+      backgroundColor: '#10B981',
+      paddingVertical: 12,
+      borderRadius: 8,
+      alignItems: 'center',
+    },
+    buttonText: {
+      color: '#FFFFFF',
+      fontWeight: '600',
       fontSize: 16,
-      color: colors.textSecondary,
-      textAlign: 'center',
     },
   });

--- a/project/app/settings.tsx
+++ b/project/app/settings.tsx
@@ -1,14 +1,61 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Switch,
+  TouchableOpacity,
+} from 'react-native';
 import { useTheme } from '@/context/ThemeContext';
 
 export default function SettingsScreen() {
-  const { colors } = useTheme();
+  const { colors, theme, toggleTheme } = useTheme();
+  const [units, setUnits] = useState<'metric' | 'imperial'>('metric');
+
   const styles = getStyles(colors);
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Paramètres</Text>
-      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Mode sombre</Text>
+        <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
+      </View>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Unités</Text>
+        <View style={styles.unitsContainer}>
+          <TouchableOpacity
+            style={[
+              styles.unitButton,
+              units === 'metric' && styles.unitButtonActive,
+            ]}
+            onPress={() => setUnits('metric')}
+          >
+            <Text
+              style={units === 'metric' ? styles.unitTextActive : styles.unitText}
+            >
+              Métrique
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.unitButton,
+              units === 'imperial' && styles.unitButtonActive,
+            ]}
+            onPress={() => setUnits('imperial')}
+          >
+            <Text
+              style={
+                units === 'imperial' ? styles.unitTextActive : styles.unitText
+              }
+            >
+              Impérial
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
     </View>
   );
 }
@@ -17,20 +64,46 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
       backgroundColor: colors.background,
       padding: 20,
     },
     title: {
       fontSize: 24,
       fontWeight: 'bold',
-      marginBottom: 12,
+      marginBottom: 20,
+      color: colors.text,
+      textAlign: 'center',
+    },
+    row: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 20,
+    },
+    label: {
+      fontSize: 16,
       color: colors.text,
     },
-    text: {
-      fontSize: 16,
-      color: colors.textSecondary,
-      textAlign: 'center',
+    unitsContainer: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    unitButton: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 6,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    unitButtonActive: {
+      backgroundColor: '#10B98120',
+      borderColor: '#10B981',
+    },
+    unitText: {
+      color: colors.text,
+    },
+    unitTextActive: {
+      color: '#10B981',
+      fontWeight: '600',
     },
   });

--- a/project/app/support.tsx
+++ b/project/app/support.tsx
@@ -5,10 +5,28 @@ import { useTheme } from '@/context/ThemeContext';
 export default function SupportScreen() {
   const { colors } = useTheme();
   const styles = getStyles(colors);
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Support</Text>
-      <Text style={styles.text}>Cette page sera prochainement disponible.</Text>
+      <Text style={styles.paragraph}>
+        Pour toute question, contactez-nous à{' '}
+        <Text style={styles.link}>support@example.com</Text>.
+      </Text>
+
+      <View style={styles.faqSection}>
+        <Text style={styles.subtitle}>FAQ</Text>
+        <Text style={styles.question}>Comment réinitialiser mon mot de passe ?</Text>
+        <Text style={styles.answer}>
+          Utilisez la fonction "Mot de passe oublié" sur l'écran de connexion et
+          suivez les instructions.
+        </Text>
+        <Text style={styles.question}>Comment modifier mes informations ?</Text>
+        <Text style={styles.answer}>
+          Rendez-vous dans la section "Mon compte" pour mettre à jour votre
+          profil.
+        </Text>
+      </View>
     </View>
   );
 }
@@ -17,20 +35,41 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
       backgroundColor: colors.background,
       padding: 20,
     },
     title: {
       fontSize: 24,
       fontWeight: 'bold',
+      marginBottom: 20,
+      color: colors.text,
+      textAlign: 'center',
+    },
+    paragraph: {
+      fontSize: 16,
+      color: colors.text,
+      marginBottom: 20,
+    },
+    link: {
+      color: '#10B981',
+    },
+    faqSection: {
+      marginTop: 10,
+    },
+    subtitle: {
+      fontSize: 18,
+      fontWeight: '600',
       marginBottom: 12,
       color: colors.text,
     },
-    text: {
+    question: {
       fontSize: 16,
+      color: colors.text,
+      marginBottom: 4,
+    },
+    answer: {
+      fontSize: 14,
       color: colors.textSecondary,
-      textAlign: 'center',
+      marginBottom: 12,
     },
   });


### PR DESCRIPTION
## Summary
- implement a real form on **Mon compte** page
- add theme and unit settings
- provide a simple FAQ on the support page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845b18bb11083259e0a411f8c61828f