### PR TITLE
Add weight entry modal

### DIFF
--- a/project/app/(tabs)/progress.tsx
+++ b/project/app/(tabs)/progress.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Image } from 'react-native';
 import { TrendingUp, Camera, Calendar, Target, Award, ChevronRight, Scale, Ruler } from 'lucide-react-native';
 import ProgressChart from '@/components/ProgressChart';
+import AddWeightModal from '@/components/AddWeightModal';
 import { getWeights, WeightEntry } from '@/storage';
 import { useTheme } from '@/context/ThemeContext';
 
@@ -26,6 +27,7 @@ export default function Progress() {
   ];
 
   const [weightData, setWeightData] = useState<WeightEntry[]>([]);
+  const [showAddWeight, setShowAddWeight] = useState(false);
 
   useEffect(() => {
     getWeights().then((data) => {
@@ -156,6 +158,15 @@ export default function Progress() {
         <Text style={styles.bmiDescription}>
           Votre IMC est dans la plage normale. Continuez sur cette voie !
         </Text>
+      </View>
+
+      <View style={styles.card}>
+        <TouchableOpacity
+          style={styles.addWeightButton}
+          onPress={() => setShowAddWeight(true)}
+        >
+          <Text style={styles.addWeightText}>+ Nouveau poids</Text>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -299,6 +310,12 @@ export default function Progress() {
           ))}
         </View>
       </ScrollView>
+
+      <AddWeightModal
+        visible={showAddWeight}
+        onClose={() => setShowAddWeight(false)}
+        onSaved={setWeightData}
+      />
     </View>
   );
 }
@@ -527,6 +544,19 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     borderStyle: 'dashed',
   },
   addMeasurementText: {
+    color: colors.textSecondary,
+    fontWeight: '600',
+  },
+  addWeightButton: {
+    backgroundColor: colors.card,
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: colors.border,
+    borderStyle: 'dashed',
+  },
+  addWeightText: {
     color: colors.textSecondary,
     fontWeight: '600',
   },

--- a/project/components/AddWeightModal.tsx
+++ b/project/components/AddWeightModal.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
+import { X } from 'lucide-react-native';
+import { getWeights, saveWeights, WeightEntry } from '@/storage';
+import { useTheme } from '@/context/ThemeContext';
+
+interface AddWeightModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSaved?: (weights: WeightEntry[]) => void;
+}
+
+export default function AddWeightModal({ visible, onClose, onSaved }: AddWeightModalProps) {
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
+  const [value, setValue] = useState('');
+
+  const handleSave = async () => {
+    const weight = parseFloat(value.replace(',', '.'));
+    if (isNaN(weight)) {
+      return;
+    }
+    const current = await getWeights();
+    const entry = { date: new Date().toISOString(), value: weight };
+    const updated = [...current, entry];
+    await saveWeights(updated);
+    onSaved && onSaved(updated);
+    setValue('');
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Ajouter un poids</Text>
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <X size={24} color="#6B7280" />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.content}>
+          <TextInput
+            style={styles.input}
+            placeholder="Poids (kg)"
+            keyboardType="numeric"
+            value={value}
+            onChangeText={setValue}
+          />
+          <TouchableOpacity style={[styles.addButton, { opacity: value ? 1 : 0.5 }]} onPress={handleSave} disabled={!value}>
+            <Text style={styles.addButtonText}>Enregistrer</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: 20,
+      paddingTop: 60,
+      backgroundColor: colors.card,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: colors.text,
+    },
+    closeButton: {
+      padding: 8,
+    },
+    content: {
+      flex: 1,
+      padding: 20,
+    },
+    input: {
+      backgroundColor: colors.card,
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      fontSize: 16,
+      color: colors.text,
+      borderWidth: 1,
+      borderColor: colors.border,
+      marginBottom: 16,
+    },
+    addButton: {
+      backgroundColor: '#10B981',
+      borderRadius: 12,
+      padding: 16,
+      alignItems: 'center',
+    },
+    addButtonText: {
+      color: 'white',
+      fontSize: 16,
+      fontWeight: 'bold',
+    },
+  });


### PR DESCRIPTION
## Summary
- add `AddWeightModal` component to record new weight entries
- integrate modal in progress screen and show button in weight tab

## Testing
- `npm install --legacy-peer-deps`
- `npx tsc --noEmit` *(fails: Property 'secondary' does not exist on type 'ThemeColors', etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bae6bdfc832599cba3cb4d9efb1e