### PR TITLE
Add progress tracking storage and modal

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -18,6 +18,7 @@
     "expo": "^53.0.0",
     "expo-blur": "~14.1.3",
     "expo-camera": "~16.1.5",
+    "expo-image-picker": "~16.1.4",
     "expo-constants": "~17.1.3",
     "expo-font": "~13.2.2",
     "expo-haptics": "~14.1.3",

--- a/project/storage.ts
+++ b/project/storage.ts
@@ -42,3 +42,36 @@ export async function getWorkouts(): Promise<WorkoutEntry[]> {
 export async function saveWorkouts(workouts: WorkoutEntry[]) {
   await AsyncStorage.setItem('workouts', JSON.stringify(workouts));
 }
+
+export interface MeasurementEntry {
+  id: number;
+  name: string;
+  value: number;
+  unit: string;
+  date: string;
+}
+
+export async function getMeasurements(): Promise<MeasurementEntry[]> {
+  const data = await AsyncStorage.getItem('measurements');
+  return data ? JSON.parse(data) : [];
+}
+
+export async function saveMeasurements(measurements: MeasurementEntry[]) {
+  await AsyncStorage.setItem('measurements', JSON.stringify(measurements));
+}
+
+export interface ProgressPhoto {
+  id: number;
+  uri: string;
+  type: string;
+  date: string;
+}
+
+export async function getPhotos(): Promise<ProgressPhoto[]> {
+  const data = await AsyncStorage.getItem('photos');
+  return data ? JSON.parse(data) : [];
+}
+
+export async function savePhotos(photos: ProgressPhoto[]) {
+  await AsyncStorage.setItem('photos', JSON.stringify(photos));
+}


### PR DESCRIPTION
## Summary
- add storage helpers for measurements and photos
- integrate photo picker and measurement form in Progress screen
- allow adding new measurements and photos
- include expo-image-picker dependency

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bae7d15c8325a3b8e47bedbc8742