### PR TITLE
Add tests for key components and screens

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -68,7 +68,11 @@ export default function Dashboard() {
     >
       {/* Header */}
       <View style={[styles.header, { backgroundColor: goalColors.secondary }]}>
-        <TouchableOpacity onPress={toggleTheme} style={styles.themeToggle}>
+        <TouchableOpacity
+          testID="toggle-theme"
+          onPress={toggleTheme}
+          style={styles.themeToggle}
+        >
           {theme === 'light' ? (
             <Moon size={24} color="#1F2937" />
           ) : (

--- a/project/app/__tests__/Dashboard.test.tsx
+++ b/project/app/__tests__/Dashboard.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+const mockToggleTheme = jest.fn();
+const pushMock = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn()
+}));
+
+jest.mock('@/context/ThemeContext', () => {
+  const React = require('react');
+  const value = {
+    theme: 'light',
+    colors: {
+      background: '#fff',
+      card: '#fff',
+      text: '#000',
+      textSecondary: '#888',
+      border: '#ccc',
+      secondary: '#eee'
+    },
+    toggleTheme: mockToggleTheme
+  };
+  return {
+    ThemeProvider: ({ children }: any) => <>{children}</>,
+    useTheme: () => value
+  };
+});
+
+jest.mock('@/context/UserContext', () => {
+  const React = require('react');
+  return {
+    UserProvider: ({ children }: any) => <>{children}</>,
+    useUser: () => ({ user: { name: 'John Doe', goal: 'weight_loss' }, setUser: jest.fn() })
+  };
+});
+
+// Import the component after mocks so they take effect
+import Dashboard from '../(tabs)/index';
+import { useRouter } from 'expo-router';
+(useRouter as jest.Mock).mockReturnValue({ push: pushMock });
+
+describe('Dashboard screen', () => {
+  it('renders welcome text and triggers quick action', () => {
+    const { getByText, getByTestId } = render(<Dashboard />);
+
+    expect(getByText(/Bonjour/)).toBeTruthy();
+
+    fireEvent.press(getByText('Ajouter un repas'));
+    expect(pushMock).toHaveBeenCalledWith('/meals');
+  });
+});

--- a/project/app/__tests__/Progress.test.tsx
+++ b/project/app/__tests__/Progress.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import Progress from '../(tabs)/progress';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() })
+}));
+
+jest.mock('@/context/ThemeContext', () => {
+  const React = require('react');
+  return {
+    ThemeProvider: ({ children }: any) => <>{children}</>,
+    useTheme: () => ({
+      colors: {
+        background: '#fff',
+        card: '#fff',
+        text: '#000',
+        textSecondary: '#888',
+        border: '#ccc',
+        secondary: '#eee'
+      }
+    })
+  };
+});
+
+jest.mock('@/storage', () => ({
+  getWeights: jest.fn(() => Promise.resolve([
+    { date: '2024-01-01', value: 70 },
+    { date: '2024-01-02', value: 69 }
+  ])),
+}));
+
+describe('Progress screen', () => {
+  it('switches tabs', async () => {
+    const { getByText } = render(<Progress />);
+
+    await waitFor(() => {
+      expect(getByText('Évolution du poids')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Mensurations'));
+
+    await waitFor(() => {
+      expect(getByText('Évolution des mensurations')).toBeTruthy();
+    });
+  });
+});

--- a/project/app/__tests__/Workouts.test.tsx
+++ b/project/app/__tests__/Workouts.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import Workouts from '../(tabs)/workouts';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() })
+}));
+
+jest.mock('@/context/ThemeContext', () => {
+  const React = require('react');
+  return {
+    ThemeProvider: ({ children }: any) => <>{children}</>,
+    useTheme: () => ({
+      colors: {
+        background: '#fff',
+        card: '#fff',
+        text: '#000',
+        textSecondary: '#888',
+        border: '#ccc',
+        secondary: '#eee'
+      }
+    })
+  };
+});
+
+jest.mock('@/storage', () => ({
+  getWorkouts: jest.fn(() => Promise.resolve([])),
+  saveWorkouts: jest.fn()
+}));
+
+describe('Workouts screen', () => {
+  it('changes category when a tab is pressed', async () => {
+    const { getByText } = render(<Workouts />);
+
+    fireEvent.press(getByText('Cardio'));
+
+    await waitFor(() => {
+      expect(getByText('Recommandés pour vous • Cardio')).toBeTruthy();
+    });
+  });
+});

--- a/project/components/WorkoutTimer.tsx
+++ b/project/components/WorkoutTimer.tsx
@@ -67,20 +67,36 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
       
       <View style={styles.controls}>
         {!isRunning || isPaused ? (
-          <TouchableOpacity style={[styles.button, styles.playButton]} onPress={handleStart}>
+          <TouchableOpacity
+            testID="start-button"
+            style={[styles.button, styles.playButton]}
+            onPress={handleStart}
+          >
             <Play size={20} color="white" />
           </TouchableOpacity>
         ) : (
-          <TouchableOpacity style={[styles.button, styles.pauseButton]} onPress={handlePause}>
+          <TouchableOpacity
+            testID="pause-button"
+            style={[styles.button, styles.pauseButton]}
+            onPress={handlePause}
+          >
             <Pause size={20} color="white" />
           </TouchableOpacity>
         )}
-        
-        <TouchableOpacity style={[styles.button, styles.stopButton]} onPress={handleStop}>
+
+        <TouchableOpacity
+          testID="stop-button"
+          style={[styles.button, styles.stopButton]}
+          onPress={handleStop}
+        >
           <Square size={20} color="white" />
         </TouchableOpacity>
-        
-        <TouchableOpacity style={[styles.button, styles.resetButton]} onPress={handleReset}>
+
+        <TouchableOpacity
+          testID="reset-button"
+          style={[styles.button, styles.resetButton]}
+          onPress={handleReset}
+        >
           <RotateCcw size={20} color="#6B7280" />
         </TouchableOpacity>
       </View>

--- a/project/components/__tests__/ProgressChart.test.tsx
+++ b/project/components/__tests__/ProgressChart.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ProgressChart from '../ProgressChart';
+
+describe('ProgressChart', () => {
+  it('renders empty state', () => {
+    const { getByText } = render(
+      <ProgressChart data={[]} color="#000" />
+    );
+    expect(getByText('Aucune donnée disponible')).toBeTruthy();
+  });
+
+  it('renders data points', () => {
+    const data = [
+      { date: '2024-01-01', value: 10 },
+      { date: '2024-01-02', value: 12 }
+    ];
+    const { getByText } = render(
+      <ProgressChart data={data} color="#000" unit="kg" />
+    );
+    expect(getByText('10kg')).toBeTruthy();
+    expect(getByText('12kg')).toBeTruthy();
+  });
+});

--- a/project/components/__tests__/WorkoutTimer.test.tsx
+++ b/project/components/__tests__/WorkoutTimer.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import WorkoutTimer from '../WorkoutTimer';
+
+jest.useFakeTimers();
+
+describe('WorkoutTimer', () => {
+  it('handles start, pause and stop', () => {
+    const onComplete = jest.fn();
+    const { getByText, getByTestId } = render(
+      <WorkoutTimer onComplete={onComplete} />
+    );
+
+    // initial state
+    expect(getByText('Prêt')).toBeTruthy();
+
+    // start timer
+    fireEvent.press(getByTestId('start-button'));
+    expect(getByText('En cours')).toBeTruthy();
+
+    // pause timer
+    fireEvent.press(getByTestId('pause-button'));
+    expect(getByText('En pause')).toBeTruthy();
+
+    // stop timer
+    fireEvent.press(getByTestId('stop-button'));
+    expect(onComplete).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add testIDs to WorkoutTimer buttons and header toggle
- unit tests for WorkoutTimer and ProgressChart components
- screen tests for Dashboard, Workouts and Progress
- ensure tests run with jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bae992d4832595a5b5c1e894d1b7