### PR TITLE
Implement authentication screens

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -82,7 +82,11 @@ export default function Dashboard() {
         
         <TouchableOpacity
           style={[styles.goalBadge, { backgroundColor: goalColors.primary }]}
-          onPress={() => setUser(u => ({ ...u, goal: u.goal === 'weight_loss' ? 'muscle_gain' : 'weight_loss' }))}
+          onPress={() =>
+            setUser((u) =>
+              u ? { ...u, goal: u.goal === 'weight_loss' ? 'muscle_gain' : 'weight_loss' } : u
+            )
+          }
         >
           <Text style={styles.goalText}>
             {user.goal === 'weight_loss' ? '🔥 Perte de poids' : '💪 Prise de masse'}

--- a/project/app/_layout.tsx
+++ b/project/app/_layout.tsx
@@ -1,13 +1,27 @@
 import { useEffect } from 'react';
-import { Stack } from 'expo-router';
+import { Stack, useSegments, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
-import { UserProvider } from '@/context/UserContext';
+import { UserProvider, useUser } from '@/context/UserContext';
 import { ThemeProvider, useTheme } from '@/context/ThemeContext';
 import { View } from 'react-native';
 
 function AppContainer() {
   const { colors, theme } = useTheme();
+  const { user, loading } = useUser();
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    const inAuth = segments[0] === 'login' || segments[0] === 'register';
+    if (!user && !inAuth) {
+      router.replace('/login');
+    } else if (user && inAuth) {
+      router.replace('/');
+    }
+  }, [user, loading, segments]);
+
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
       <Stack
@@ -17,6 +31,8 @@ function AppContainer() {
         }}
       >
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="login" />
+        <Stack.Screen name="register" />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style={theme === 'dark' ? 'light' : 'dark'} />

--- a/project/app/login.tsx
+++ b/project/app/login.tsx
@@ -1,54 +1,26 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-} from 'react-native';
-import { useTheme } from '@/context/ThemeContext';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { useRouter, Link } from 'expo-router';
 import { useUser } from '@/context/UserContext';
+import { useTheme } from '@/context/ThemeContext';
 
-export default function AccountScreen() {
+export default function Login() {
+  const { login } = useUser();
   const { colors } = useTheme();
-  const { user, setUser } = useUser();
-
-  if (!user) {
-    return null;
-  }
-
-  const [name, setName] = useState(user.name);
-  const [email, setEmail] = useState(user.email);
-  const [age, setAge] = useState(String(user.age));
-  const [height, setHeight] = useState(String(user.height));
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   const styles = getStyles(colors);
 
-  const saveProfile = () => {
-    setUser((u) =>
-      u
-        ? {
-            ...u,
-            name,
-            email,
-            age: Number(age),
-            height: Number(height),
-          }
-        : u
-    );
+  const handleLogin = async () => {
+    await login(email, password);
+    router.replace('/');
   };
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Mon compte</Text>
-      <View style={styles.formRow}>
-        <Text style={styles.label}>Nom</Text>
-        <TextInput
-          style={styles.input}
-          value={name}
-          onChangeText={setName}
-        />
-      </View>
+      <Text style={styles.title}>Connexion</Text>
       <View style={styles.formRow}>
         <Text style={styles.label}>Email</Text>
         <TextInput
@@ -56,29 +28,22 @@ export default function AccountScreen() {
           value={email}
           onChangeText={setEmail}
           keyboardType="email-address"
+          autoCapitalize="none"
         />
       </View>
       <View style={styles.formRow}>
-        <Text style={styles.label}>Âge</Text>
+        <Text style={styles.label}>Mot de passe</Text>
         <TextInput
           style={styles.input}
-          value={age}
-          onChangeText={setAge}
-          keyboardType="numeric"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
         />
       </View>
-      <View style={styles.formRow}>
-        <Text style={styles.label}>Taille (cm)</Text>
-        <TextInput
-          style={styles.input}
-          value={height}
-          onChangeText={setHeight}
-          keyboardType="numeric"
-        />
-      </View>
-      <TouchableOpacity style={styles.button} onPress={saveProfile}>
-        <Text style={styles.buttonText}>Sauvegarder</Text>
+      <TouchableOpacity style={styles.button} onPress={handleLogin}>
+        <Text style={styles.buttonText}>Se connecter</Text>
       </TouchableOpacity>
+      <Link href="/register" style={styles.link}>Pas encore de compte ? Inscription</Link>
     </View>
   );
 }
@@ -89,6 +54,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
       flex: 1,
       backgroundColor: colors.background,
       padding: 20,
+      justifyContent: 'center',
     },
     title: {
       fontSize: 24,
@@ -124,5 +90,10 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
       color: '#FFFFFF',
       fontWeight: '600',
       fontSize: 16,
+    },
+    link: {
+      marginTop: 16,
+      textAlign: 'center',
+      color: '#3B82F6',
     },
   });

--- a/project/app/register.tsx
+++ b/project/app/register.tsx
@@ -1,53 +1,31 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-} from 'react-native';
-import { useTheme } from '@/context/ThemeContext';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { useRouter, Link } from 'expo-router';
 import { useUser } from '@/context/UserContext';
+import { useTheme } from '@/context/ThemeContext';
 
-export default function AccountScreen() {
+export default function Register() {
+  const { register } = useUser();
   const { colors } = useTheme();
-  const { user, setUser } = useUser();
+  const router = useRouter();
 
-  if (!user) {
-    return null;
-  }
-
-  const [name, setName] = useState(user.name);
-  const [email, setEmail] = useState(user.email);
-  const [age, setAge] = useState(String(user.age));
-  const [height, setHeight] = useState(String(user.height));
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   const styles = getStyles(colors);
 
-  const saveProfile = () => {
-    setUser((u) =>
-      u
-        ? {
-            ...u,
-            name,
-            email,
-            age: Number(age),
-            height: Number(height),
-          }
-        : u
-    );
+  const handleRegister = async () => {
+    await register(name, email, password);
+    router.replace('/');
   };
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Mon compte</Text>
+      <Text style={styles.title}>Inscription</Text>
       <View style={styles.formRow}>
         <Text style={styles.label}>Nom</Text>
-        <TextInput
-          style={styles.input}
-          value={name}
-          onChangeText={setName}
-        />
+        <TextInput style={styles.input} value={name} onChangeText={setName} />
       </View>
       <View style={styles.formRow}>
         <Text style={styles.label}>Email</Text>
@@ -56,29 +34,22 @@ export default function AccountScreen() {
           value={email}
           onChangeText={setEmail}
           keyboardType="email-address"
+          autoCapitalize="none"
         />
       </View>
       <View style={styles.formRow}>
-        <Text style={styles.label}>Âge</Text>
+        <Text style={styles.label}>Mot de passe</Text>
         <TextInput
           style={styles.input}
-          value={age}
-          onChangeText={setAge}
-          keyboardType="numeric"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
         />
       </View>
-      <View style={styles.formRow}>
-        <Text style={styles.label}>Taille (cm)</Text>
-        <TextInput
-          style={styles.input}
-          value={height}
-          onChangeText={setHeight}
-          keyboardType="numeric"
-        />
-      </View>
-      <TouchableOpacity style={styles.button} onPress={saveProfile}>
-        <Text style={styles.buttonText}>Sauvegarder</Text>
+      <TouchableOpacity style={styles.button} onPress={handleRegister}>
+        <Text style={styles.buttonText}>Créer le compte</Text>
       </TouchableOpacity>
+      <Link href="/login" style={styles.link}>Déjà inscrit ? Se connecter</Link>
     </View>
   );
 }
@@ -89,6 +60,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
       flex: 1,
       backgroundColor: colors.background,
       padding: 20,
+      justifyContent: 'center',
     },
     title: {
       fontSize: 24,
@@ -124,5 +96,10 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
       color: '#FFFFFF',
       fontWeight: '600',
       fontSize: 16,
+    },
+    link: {
+      marginTop: 16,
+      textAlign: 'center',
+      color: '#3B82F6',
     },
   });

--- a/project/auth.ts
+++ b/project/auth.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { User } from './context/UserContext';
+
+const USER_KEY = 'auth_user';
+
+export async function getPersistedUser(): Promise<User | null> {
+  const data = await AsyncStorage.getItem(USER_KEY);
+  return data ? JSON.parse(data) : null;
+}
+
+export async function persistUser(user: User) {
+  await AsyncStorage.setItem(USER_KEY, JSON.stringify(user));
+}
+
+export async function clearPersistedUser() {
+  await AsyncStorage.removeItem(USER_KEY);
+}
+
+export async function fakeLogin(email: string, password: string): Promise<User> {
+  // Simple fake user based on email
+  const existing = await getPersistedUser();
+  if (existing && existing.email === email) {
+    return existing;
+  }
+  const user: User = {
+    name: 'Utilisateur',
+    email,
+    age: 30,
+    height: 170,
+    goal: 'weight_loss',
+    joinDate: new Date().toISOString().split('T')[0],
+    level: 'Débutant',
+  };
+  await persistUser(user);
+  return user;
+}
+
+export async function fakeRegister(name: string, email: string, password: string): Promise<User> {
+  const user: User = {
+    name,
+    email,
+    age: 30,
+    height: 170,
+    goal: 'weight_loss',
+    joinDate: new Date().toISOString().split('T')[0],
+    level: 'Débutant',
+  };
+  await persistUser(user);
+  return user;
+}
+


### PR DESCRIPTION
## Summary
- add fake auth API with persistence
- update `UserContext` to load/save current user
- add login and register screens
- protect app routes in `_layout`
- make profile update functions null-safe

## Testing
- `npx tsc --noEmit` *(fails: numerous type errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bae8186483258657246bbd310883