### PR TITLE
Fix crash when user context not loaded

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -24,12 +24,16 @@ import { useTheme } from '@/context/ThemeContext';
 const { width } = Dimensions.get('window');
 
 export default function Dashboard() {
-  const { user, setUser } = useUser();
+  const { user, setUser, loading } = useUser();
   const router = useRouter();
   const { theme, toggleTheme, colors } = useTheme();
   const [currentWeight] = useState(68);
   const [targetWeight] = useState(60);
   const [weeklyProgress] = useState(75);
+
+  if (loading || !user) {
+    return null;
+  }
 
   const goalPalettes = {
     weight_loss: {

--- a/project/app/(tabs)/plan.tsx
+++ b/project/app/(tabs)/plan.tsx
@@ -9,9 +9,13 @@ const { width } = Dimensions.get('window');
 
 export default function Plan() {
   const [activeTab, setActiveTab] = useState<'nutrition' | 'workout' | 'lifestyle'>('nutrition');
-  const { user } = useUser();
+  const { user, loading } = useUser();
   const router = useRouter();
   const { colors } = useTheme();
+
+  if (loading || !user) {
+    return null;
+  }
 
   const goalPalettes = {
     weight_loss: {

--- a/project/app/(tabs)/profile.tsx
+++ b/project/app/(tabs)/profile.tsx
@@ -7,10 +7,14 @@ import { useTheme } from '@/context/ThemeContext';
 
 export default function Profile() {
   const [notifications, setNotifications] = useState(true);
-  const { user } = useUser();
+  const { user, loading } = useUser();
   const router = useRouter();
   const { colors } = useTheme();
   const styles = getStyles(colors);
+
+  if (loading || !user) {
+    return null;
+  }
 
   const [preferences] = useState({
     dietType: 'Équilibrée',


### PR DESCRIPTION
## Summary
- guard against missing user in dashboard, plan, and profile screens

## Testing
- `npx tsc --noEmit` *(fails: cannot find name 'expect', etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c357a03c832586491dab3fcfd4e0