### PR TITLE
Enhance workouts UI and add history screen

### DIFF
--- a/project/app/(tabs)/plan.tsx
+++ b/project/app/(tabs)/plan.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
 import { Utensils, Activity, Moon, Droplets, Brain, ChevronRight, Target } from 'lucide-react-native';
+import ProgressChart from '@/components/ProgressChart';
 import { useUser } from '@/context/UserContext';
 import { useRouter } from 'expo-router';
 import { useTheme } from '@/context/ThemeContext';
@@ -155,7 +156,14 @@ export default function Plan() {
     </View>
   );
 
-  const renderWorkoutTab = () => (
+  const renderWorkoutTab = () => {
+    const progressRatio = workoutPlan.completed / workoutPlan.weeklyGoal;
+    const progressColor = progressRatio >= 1 ? '#10B981' : goalColors.primary;
+    const progressData = workoutPlan.sessions.map((s, i) => ({
+      date: `${i + 1}`,
+      value: s.status === 'completed' ? 1 : 0,
+    }));
+    return (
     <View>
       {/* Weekly Progress */}
       <View style={[styles.card, { backgroundColor: colors.card }]}>
@@ -171,12 +179,18 @@ export default function Plan() {
             style={[
               styles.progressFill,
               { 
-                width: `${(workoutPlan.completed / workoutPlan.weeklyGoal) * 100}%`,
-                backgroundColor: goalColors.primary
+                width: `${progressRatio * 100}%`,
+                backgroundColor: progressColor
               }
-            ]} 
+            ]}
           />
         </View>
+        <ProgressChart
+          data={progressData}
+          color={progressColor}
+          minValue={0}
+          maxValue={1}
+        />
       </View>
 
       {/* Weekly Schedule */}
@@ -201,6 +215,7 @@ export default function Plan() {
       </View>
     </View>
   );
+  };
 
   const renderLifestyleTab = () => (
     <View>

--- a/project/app/(tabs)/workouts.tsx
+++ b/project/app/(tabs)/workouts.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Modal, TextInput, Switch } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Modal, TextInput, Switch, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
 import Slider from '@react-native-community/slider';
 import { Play, Plus, Clock, Zap, Target, Trophy, ChevronRight, Activity, Heart, X, Dumbbell, StretchHorizontal, Bookmark, Repeat } from 'lucide-react-native';
 import WorkoutTimer from '@/components/WorkoutTimer';
@@ -19,6 +20,7 @@ export default function Workouts() {
   const [newWorkoutType, setNewWorkoutType] = useState<'cardio' | 'strength' | 'flexibility'>('cardio');
   const [newWorkoutLevel, setNewWorkoutLevel] = useState<'Débutant' | 'Intermédiaire' | 'Avancé'>('Débutant');
   const { colors } = useTheme();
+  const router = useRouter();
   const styles = getStyles(colors);
   const [newWorkoutCalories, setNewWorkoutCalories] = useState(240);
   const [newWorkoutEquipment, setNewWorkoutEquipment] = useState('');
@@ -272,6 +274,7 @@ export default function Workouts() {
             >
               <Plus size={24} color="#6B7280" />
               <Text style={styles.createWorkoutText}>Créer un entraînement</Text>
+              <Text style={styles.createWorkoutSubtitle}>Personnalise ta séance !</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -283,10 +286,13 @@ export default function Workouts() {
             {selectedCategory !== 'all' && ` • ${categories.find(c => c.key === selectedCategory)?.label}`}
           </Text>
           {filteredWorkouts.map((workout, index) => (
-            <TouchableOpacity 
-              key={index} 
-              style={styles.workoutCard}
+            <Pressable
+              key={index}
               onPress={() => startWorkout(workout)}
+              style={({ pressed }) => [
+                styles.workoutCard,
+                pressed && { transform: [{ scale: 0.97 }] },
+              ]}
             >
               <View style={styles.workoutLeft}>
                 <View style={styles.workoutIcon}>
@@ -313,15 +319,15 @@ export default function Workouts() {
                 </View>
               </View>
               <Play size={20} color="#10B981" />
-            </TouchableOpacity>
+            </Pressable>
           ))}
         </View>
 
         {/* Workout History */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Historique récent</Text>
-          {workoutHistory.map((workout) => (
-            <View key={workout.id} style={styles.historyCard}>
+        {workoutHistory.map((workout) => (
+          <View key={workout.id} style={styles.historyCard}>
               <View style={styles.historyLeft}>
                 <View style={styles.historyStatus}>
                   <View style={[styles.statusIndicator, { backgroundColor: '#10B981' }]} />
@@ -342,9 +348,15 @@ export default function Workouts() {
                 </View>
               </View>
               <ChevronRight size={16} color="#9CA3AF" />
-            </View>
-          ))}
-        </View>
+          </View>
+        ))}
+        <TouchableOpacity
+          style={styles.historyButton}
+          onPress={() => router.push('/history')}
+        >
+          <Text style={styles.historyButtonText}>Voir tout l'historique</Text>
+        </TouchableOpacity>
+      </View>
 
         {/* Progress Insights */}
         <View style={styles.section}>
@@ -663,10 +675,16 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     borderStyle: 'dashed',
   },
   createWorkoutText: {
-    color: colors.textSecondary,
+    color: colors.text,
     fontSize: 12,
     fontWeight: '600',
     marginTop: 8,
+    textAlign: 'center',
+  },
+  createWorkoutSubtitle: {
+    color: colors.textSecondary,
+    fontSize: 10,
+    marginTop: 4,
     textAlign: 'center',
   },
   workoutCard: {
@@ -708,7 +726,7 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
   },
   workoutDescription: {
     fontSize: 14,
-    color: colors.textSecondary,
+    color: colors.text,
     marginBottom: 8,
   },
   workoutMeta: {
@@ -964,5 +982,14 @@ const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
     color: 'white',
     fontSize: 16,
     fontWeight: 'bold',
+  },
+  historyButton: {
+    marginTop: 8,
+    padding: 12,
+    alignItems: 'center',
+  },
+  historyButtonText: {
+    color: '#10B981',
+    fontWeight: '600',
   },
 });

--- a/project/app/history.tsx
+++ b/project/app/history.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { ChevronLeft } from 'lucide-react-native';
+import { getWorkouts, WorkoutEntry } from '@/storage';
+import { useTheme } from '@/context/ThemeContext';
+import { useRouter } from 'expo-router';
+
+export default function HistoryScreen() {
+  const { colors } = useTheme();
+  const router = useRouter();
+  const [history, setHistory] = useState<WorkoutEntry[]>([]);
+
+  useEffect(() => {
+    getWorkouts().then(setHistory);
+  }, []);
+
+  const styles = getStyles(colors);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <ChevronLeft size={20} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Historique complet</Text>
+      </View>
+      <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
+        {history.map((workout) => (
+          <View key={workout.id} style={styles.item}>
+            <Text style={styles.itemName}>{workout.name}</Text>
+            <Text style={styles.itemMeta}>
+              {new Date(workout.date).toLocaleDateString('fr-FR')} • {workout.duration} min
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 20,
+    },
+    backButton: {
+      marginRight: 12,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: colors.text,
+    },
+    list: {
+      flex: 1,
+      paddingHorizontal: 20,
+    },
+    item: {
+      backgroundColor: colors.card,
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 12,
+    },
+    itemName: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.text,
+    },
+    itemMeta: {
+      fontSize: 12,
+      color: colors.textSecondary,
+      marginTop: 4,
+    },
+  });


### PR DESCRIPTION
## Summary
- improve readability on workout cards
- add subtitle to create workout card
- animate workout cards on press
- add full workout history screen and link from history section
- show weekly progress chart with dynamic color

## Testing
- `npm install --legacy-peer-deps`
- `npx tsc --noEmit` *(fails: 'meal.quantity' possibly undefined, etc.)*
- `npm test` *(fails: Progress screen timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6845c6b872208325b924505d1fb8ce0d