### PR TITLE
Add Tailwind styling

### DIFF
--- a/project/app/login.tsx
+++ b/project/app/login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import { useRouter, Link } from 'expo-router';
 import { useUser } from '@/context/UserContext';
 import { useTheme } from '@/context/ThemeContext';
@@ -11,89 +11,50 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const styles = getStyles(colors);
-
   const handleLogin = async () => {
     await login(email, password);
     router.replace('/');
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Connexion</Text>
-      <View style={styles.formRow}>
-        <Text style={styles.label}>Email</Text>
+    <View className="flex-1 justify-center p-5" style={{ backgroundColor: colors.background }}>
+      <Text className="text-center text-2xl font-bold mb-5" style={{ color: colors.text }}>
+        Connexion
+      </Text>
+      <View className="mb-4">
+        <Text className="mb-1 text-sm" style={{ color: colors.textSecondary }}>
+          Email
+        </Text>
         <TextInput
-          style={styles.input}
+          className="rounded-lg border p-2"
+          style={{ borderColor: colors.border, backgroundColor: colors.card, color: colors.text }}
           value={email}
           onChangeText={setEmail}
           keyboardType="email-address"
           autoCapitalize="none"
         />
       </View>
-      <View style={styles.formRow}>
-        <Text style={styles.label}>Mot de passe</Text>
+      <View className="mb-4">
+        <Text className="mb-1 text-sm" style={{ color: colors.textSecondary }}>
+          Mot de passe
+        </Text>
         <TextInput
-          style={styles.input}
+          className="rounded-lg border p-2"
+          style={{ borderColor: colors.border, backgroundColor: colors.card, color: colors.text }}
           value={password}
           onChangeText={setPassword}
           secureTextEntry
         />
       </View>
-      <TouchableOpacity style={styles.button} onPress={handleLogin}>
-        <Text style={styles.buttonText}>Se connecter</Text>
+      <TouchableOpacity
+        className="mt-5 items-center rounded-lg bg-emerald-500 py-3"
+        onPress={handleLogin}
+      >
+        <Text className="font-semibold text-white">Se connecter</Text>
       </TouchableOpacity>
-      <Link href="/register" style={styles.link}>Pas encore de compte ? Inscription</Link>
+      <Link href="/register" className="mt-4 text-center text-blue-500">
+        Pas encore de compte ? Inscription
+      </Link>
     </View>
   );
 }
-
-const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
-  StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-      padding: 20,
-      justifyContent: 'center',
-    },
-    title: {
-      fontSize: 24,
-      fontWeight: 'bold',
-      marginBottom: 20,
-      color: colors.text,
-      textAlign: 'center',
-    },
-    formRow: {
-      marginBottom: 16,
-    },
-    label: {
-      fontSize: 14,
-      color: colors.textSecondary,
-      marginBottom: 4,
-    },
-    input: {
-      borderWidth: 1,
-      borderColor: colors.border,
-      borderRadius: 8,
-      padding: 8,
-      backgroundColor: colors.card,
-      color: colors.text,
-    },
-    button: {
-      marginTop: 20,
-      backgroundColor: '#10B981',
-      paddingVertical: 12,
-      borderRadius: 8,
-      alignItems: 'center',
-    },
-    buttonText: {
-      color: '#FFFFFF',
-      fontWeight: '600',
-      fontSize: 16,
-    },
-    link: {
-      marginTop: 16,
-      textAlign: 'center',
-      color: '#3B82F6',
-    },
-  });

--- a/project/babel.config.js
+++ b/project/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
   };
 };

--- a/project/components/AddWeightModal.tsx
+++ b/project/components/AddWeightModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
+import { Modal, View, Text, TouchableOpacity, TextInput } from 'react-native';
 import { X } from 'lucide-react-native';
 import { getWeights, saveWeights, WeightEntry } from '@/storage';
 import { useTheme } from '@/context/ThemeContext';
@@ -12,7 +12,6 @@ interface AddWeightModalProps {
 
 export default function AddWeightModal({ visible, onClose, onSaved }: AddWeightModalProps) {
   const { colors } = useTheme();
-  const styles = getStyles(colors);
   const [value, setValue] = useState('');
 
   const handleSave = async () => {
@@ -36,23 +35,34 @@ export default function AddWeightModal({ visible, onClose, onSaved }: AddWeightM
       presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View style={styles.container}>
-        <View style={styles.header}>
-          <Text style={styles.title}>Ajouter un poids</Text>
-          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+      <View className="flex-1" style={{ backgroundColor: colors.background }}>
+        <View
+          className="flex-row items-center justify-between border-b p-5 pt-16"
+          style={{ backgroundColor: colors.card, borderColor: colors.border }}
+        >
+          <Text className="text-lg font-bold" style={{ color: colors.text }}>
+            Ajouter un poids
+          </Text>
+          <TouchableOpacity className="p-2" onPress={onClose}>
             <X size={24} color="#6B7280" />
           </TouchableOpacity>
         </View>
-        <View style={styles.content}>
+        <View className="flex-1 p-5">
           <TextInput
-            style={styles.input}
+            className="mb-4 rounded-xl border px-4 py-3 text-base"
+            style={{ borderColor: colors.border, backgroundColor: colors.card, color: colors.text }}
             placeholder="Poids (kg)"
             keyboardType="numeric"
             value={value}
             onChangeText={setValue}
           />
-          <TouchableOpacity style={[styles.addButton, { opacity: value ? 1 : 0.5 }]} onPress={handleSave} disabled={!value}>
-            <Text style={styles.addButtonText}>Enregistrer</Text>
+          <TouchableOpacity
+            className="items-center rounded-xl bg-emerald-500 p-4"
+            style={{ opacity: value ? 1 : 0.5 }}
+            onPress={handleSave}
+            disabled={!value}
+          >
+            <Text className="text-base font-bold text-white">Enregistrer</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -60,54 +70,3 @@ export default function AddWeightModal({ visible, onClose, onSaved }: AddWeightM
   );
 }
 
-const getStyles = (colors: import('@/context/ThemeContext').ThemeColors) =>
-  StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    header: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      padding: 20,
-      paddingTop: 60,
-      backgroundColor: colors.card,
-      borderBottomWidth: 1,
-      borderBottomColor: colors.border,
-    },
-    title: {
-      fontSize: 20,
-      fontWeight: 'bold',
-      color: colors.text,
-    },
-    closeButton: {
-      padding: 8,
-    },
-    content: {
-      flex: 1,
-      padding: 20,
-    },
-    input: {
-      backgroundColor: colors.card,
-      borderRadius: 12,
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-      fontSize: 16,
-      color: colors.text,
-      borderWidth: 1,
-      borderColor: colors.border,
-      marginBottom: 16,
-    },
-    addButton: {
-      backgroundColor: '#10B981',
-      borderRadius: 12,
-      padding: 16,
-      alignItems: 'center',
-    },
-    addButtonText: {
-      color: 'white',
-      fontSize: 16,
-      fontWeight: 'bold',
-    },
-  });

--- a/project/components/WorkoutTimer.tsx
+++ b/project/components/WorkoutTimer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { Play, Pause, Square, RotateCcw } from 'lucide-react-native';
 
 interface WorkoutTimerProps {
@@ -57,19 +57,21 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.timerDisplay}>
-        <Text style={styles.timeText}>{formatTime(time)}</Text>
-        <Text style={styles.statusText}>
+    <View className="items-center rounded-2xl bg-white p-5 shadow" >
+      <View className="mb-5 items-center">
+        <Text className="font-mono text-5xl font-bold text-gray-800">
+          {formatTime(time)}
+        </Text>
+        <Text className="mt-2 text-base text-gray-500">
           {!isRunning ? 'Prêt' : isPaused ? 'En pause' : 'En cours'}
         </Text>
       </View>
-      
-      <View style={styles.controls}>
+
+      <View className="flex-row gap-4">
         {!isRunning || isPaused ? (
           <TouchableOpacity
             testID="start-button"
-            style={[styles.button, styles.playButton]}
+            className="h-14 w-14 items-center justify-center rounded-full bg-emerald-500"
             onPress={handleStart}
           >
             <Play size={20} color="white" />
@@ -77,7 +79,7 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
         ) : (
           <TouchableOpacity
             testID="pause-button"
-            style={[styles.button, styles.pauseButton]}
+            className="h-14 w-14 items-center justify-center rounded-full bg-amber-500"
             onPress={handlePause}
           >
             <Pause size={20} color="white" />
@@ -86,7 +88,7 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
 
         <TouchableOpacity
           testID="stop-button"
-          style={[styles.button, styles.stopButton]}
+          className="h-14 w-14 items-center justify-center rounded-full bg-red-500"
           onPress={handleStop}
         >
           <Square size={20} color="white" />
@@ -94,7 +96,7 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
 
         <TouchableOpacity
           testID="reset-button"
-          style={[styles.button, styles.resetButton]}
+          className="h-14 w-14 items-center justify-center rounded-full bg-gray-100"
           onPress={handleReset}
         >
           <RotateCcw size={20} color="#6B7280" />
@@ -103,55 +105,3 @@ export default function WorkoutTimer({ onComplete, initialTime = 0 }: WorkoutTim
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: 'white',
-    borderRadius: 16,
-    padding: 20,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  timerDisplay: {
-    alignItems: 'center',
-    marginBottom: 20,
-  },
-  timeText: {
-    fontSize: 48,
-    fontWeight: 'bold',
-    color: '#1F2937',
-    fontFamily: 'monospace',
-  },
-  statusText: {
-    fontSize: 16,
-    color: '#6B7280',
-    marginTop: 8,
-  },
-  controls: {
-    flexDirection: 'row',
-    gap: 16,
-  },
-  button: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  playButton: {
-    backgroundColor: '#10B981',
-  },
-  pauseButton: {
-    backgroundColor: '#F59E0B',
-  },
-  stopButton: {
-    backgroundColor: '#EF4444',
-  },
-  resetButton: {
-    backgroundColor: '#F3F4F6',
-  },
-});

--- a/project/nativewind-env.d.ts
+++ b/project/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/project/package-lock.json
+++ b/project/package-lock.json
@@ -29,6 +29,7 @@
         "expo-system-ui": "~5.0.5",
         "expo-web-browser": "~14.1.5",
         "lucide-react-native": "^0.475.0",
+        "nativewind": "^4.1.23",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.1",
@@ -49,6 +50,7 @@
         "jest": "^29.7.0",
         "jest-expo": "^53.0.7",
         "react-test-renderer": "^19.0.0",
+        "tailwindcss": "^4.1.8",
         "typescript": "~5.8.3"
       }
     },
@@ -3367,6 +3369,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "license": "MIT"
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -4123,6 +4131,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -4220,6 +4244,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "5.2.1",
@@ -5670,6 +5700,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8103,6 +8142,23 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nativewind": {
+      "version": "4.1.23",
+      "resolved": "https://registry.npmjs.org/nativewind/-/nativewind-4.1.23.tgz",
+      "integrity": "sha512-oLX3suGI6ojQqWxdQezOSM5GmJ4KvMnMtmaSMN9Ggb5j7ysFt4nHxb1xs8RDjZR7BWc+bsetNJU8IQdQMHqRpg==",
+      "license": "MIT",
+      "dependencies": {
+        "comment-json": "^4.2.5",
+        "debug": "^4.3.7",
+        "react-native-css-interop": "0.1.22"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">3.3.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8999,6 +9055,49 @@
         }
       }
     },
+    "node_modules/react-native-css-interop": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/react-native-css-interop/-/react-native-css-interop-0.1.22.tgz",
+      "integrity": "sha512-Mu01e+H9G+fxSWvwtgWlF5MJBJC4VszTCBXopIpeR171lbeBInHb8aHqoqRPxmJpi3xIHryzqKFOJYAdk7PBxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.3.7",
+        "lightningcss": "^1.27.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.6.2",
+        "tailwindcss": "~3"
+      },
+      "peerDependenciesMeta": {
+        "react-native-safe-area-context": {
+          "optional": true
+        },
+        "react-native-svg": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-css-interop/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -9360,6 +9459,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -10250,6 +10358,13 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
       "dev": true,
       "license": "MIT"
     },

--- a/project/package.json
+++ b/project/package.json
@@ -41,7 +41,8 @@
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
-    "@react-native-community/slider": "^5.0.0"
+    "@react-native-community/slider": "^5.0.0",
+    "nativewind": "^4.1.23"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -51,6 +52,7 @@
     "jest": "^29.7.0",
     "jest-expo": "^53.0.7",
     "react-test-renderer": "^19.0.0",
+    "tailwindcss": "^4.1.8",
     "typescript": "~5.8.3"
   }
 }

--- a/project/tailwind.config.js
+++ b/project/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- integrate `nativewind` and `tailwindcss`
- enable `nativewind/babel` plugin
- add Tailwind config and type definitions
- refactor Login screen and key components to use Tailwind classes

## Testing
- `npx tsc --noEmit` *(fails: 'meal.quantity' possibly undefined, missing jest types, etc.)*
- `npm test` *(fails: .plugins is not a valid Plugin property)*

------
https://chatgpt.com/codex/tasks/task_e_6845d917a6448325a48190cc036b4648